### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 aiohttp>=3.4.4
 certifi>=2018.11.29
-attrs>=19.1.0
+attrs==19.1.0


### PR DESCRIPTION
new attrs dont supported with current wersion aiograph [see it in ruusian aiogram chat](https://t.me/aiogram_ru/207909) 
```
Traceback (most recent call last):
  File ".../app/utils/upload_rules.py", line 1, in <module>
    from aiograph import Telegraph
  File "...venv/lib/python3.7/site-packages/aiograph/__init__.py", line 1, in <module>
    from . import types
  File "...venv/lib/python3.7/site-packages/aiograph/types/__init__.py", line 6, in <module>
    from .page_list import PageList
  File "...venv/lib/python3.7/site-packages/aiograph/types/page_list.py", line 13, in <module>
    class PageList(TelegraphObject):
  File "...venv/lib/python3.7/site-packages/aiograph/types/page_list.py", line 21, in PageList
    pages: List[Page] = ib(factory=list, convert=pages_converter)
TypeError: attrib() got an unexpected keyword argument 'convert'
```