### PR TITLE
fix the attrs version and http proxy

### DIFF
--- a/aiograph/api.py
+++ b/aiograph/api.py
@@ -233,7 +233,7 @@ class Telegraph:
 
     async def request(self, method: str, *, path: Optional[str] = None, payload: Optional[dict] = None):
         url = self.format_api_url(method, path)
-        async with self.session.post(url, data=payload) as response:
+        async with self.session.post(url, data=payload, proxy=self.proxy, proxy_auth=self.proxy_auth) as response:
             json_data = await response.json(loads=self._json_deserialize)
 
             if not json_data.get('ok') and 'error' in json_data:

--- a/aiograph/api.py
+++ b/aiograph/api.py
@@ -113,9 +113,9 @@ class Telegraph:
 
         if isinstance(proxy, str) and (proxy.startswith('socks5://') or proxy.startswith('socks4://')):
             from aiohttp_socks import SocksConnector
-            from aiohttp_socks.helpers import parse_socks_url
+            from aiohttp_socks.utils import parse_proxy_url
 
-            socks_ver, host, port, username, password = parse_socks_url(proxy)
+            socks_ver, host, port, username, password = parse_proxy_url(proxy)
             if proxy_auth:
                 if not username:
                     username = proxy_auth.login

--- a/aiograph/types/__init__.py
+++ b/aiograph/types/__init__.py
@@ -8,7 +8,6 @@ from .page_views import PageViews
 
 __all__ = [
     'base',
-
     'Account',
     'AccountField',
     'NodeElement',

--- a/aiograph/types/page_list.py
+++ b/aiograph/types/page_list.py
@@ -18,4 +18,4 @@ class PageList(TelegraphObject):
     """
 
     total_count: int = ib(default=None)
-    pages: List[Page] = ib(factory=list, convert=pages_converter)
+    pages: List[Page] = ib(factory=list, converter=pages_converter)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 aiohttp>=3.4.4
 certifi>=2018.11.29
-attrs>=19.1.0
+attrs>=19.3.0

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,11 @@ def get_requirements(filename=None):
     file = WORK_DIR / filename
 
     install_reqs = parse_requirements(str(file), session='hack')
-    return [str(ir.req) for ir in install_reqs]
+    try:
+        requirements = [str(ir.req) for ir in install_reqs]
+    except:
+        requirements = [str(ir.requirement) for ir in install_reqs]
+    return requirements
 
 
 class PyTest(TestCommand):

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -95,7 +95,7 @@ def test_socks5_proxy():
     connector = telegraph.session._connector
 
     assert isinstance(connector, SocksConnector)
-    assert connector._socks_ver == SocksVer.SOCKS5
+    assert connector._socks_ver.value == SocksVer.SOCKS5
     assert connector._socks_host == 'example.com'
     assert connector._socks_port == 1050
     assert connector._socks_username == 'username'


### PR DESCRIPTION
1.the `attrs` lib is not compatible， and most people will use the 19.3.0 version. so the`convert` has been change to `converter`. the `attrs` author may think the compatible is not so good....
2. the http proxy setting takes no effect if the proxy is `http://127.0.0.1:1080` or the other http proxy.

