### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 aiohttp>=3.4.4
 certifi>=2018.11.29
-attrs>=19.3.0
+attrs==19.3.0


### PR DESCRIPTION
The `convert` keyword argument for `attrib()` was removed in attrs version 20.1.0.